### PR TITLE
Add additional entity identification codes

### DIFF
--- a/tigershark/facade/f27x.py
+++ b/tigershark/facade/f27x.py
@@ -88,7 +88,7 @@ class NamedEntity(X12SegmentBridge):
             "SEP": "Secondary Payer",
             "TTP": "Tertiary Payer",
             "VN": "Vendor",
-            "X3": "Utilization Management Organization"},raw_unknowns=True))
+            "X3": "Utilization Management Organization"}, raw_unknowns=True))
     entity_type = ElementAccess("NM1", 2, x12type=enum({
             "1": "Person",
             "2": "Non-Person Entity"}))

--- a/tigershark/facade/f27x.py
+++ b/tigershark/facade/f27x.py
@@ -69,16 +69,26 @@ class TraceNumber(X12SegmentBridge):
 class NamedEntity(X12SegmentBridge):
     entity_identifier = ElementAccess("NM1", 1, x12type=enum({
             "03": "Dependent",
+            "13": "Contracted Service Provider",
             "1P": "Provider",
             "2B": "Third-Party Administrator",
             "36": "Employer",
+            "73": "Other Physician",
             "80": "Hospital",
             "FA": "Facility",
             "GP": "Gateway Provider",
-            "IL": "Insured",
+            "IL": "Insured or Subscriber",
+            "LR": "Legal Representative",
+            "P3": "Primary Care Provider",
+            "P4": "Prior Insurance Carrier",
             "P5": "Plan Sponsor",
             "PR": "Payer",
-            "QC": "Patient"}))
+            "PRP": "Primary Payer",
+            "QC": "Patient",
+            "SEP": "Secondary Payer",
+            "TTP": "Tertiary Payer",
+            "VN": "Vendor",
+            "X3": "Utilization Management Organization"},raw_unknowns=True))
     entity_type = ElementAccess("NM1", 2, x12type=enum({
             "1": "Person",
             "2": "Non-Person Entity"}))

--- a/tigershark/facade/f27x.py
+++ b/tigershark/facade/f27x.py
@@ -77,7 +77,7 @@ class NamedEntity(X12SegmentBridge):
             "80": "Hospital",
             "FA": "Facility",
             "GP": "Gateway Provider",
-            "IL": "Insured or Subscriber",
+            "IL": "Insured",
             "LR": "Legal Representative",
             "P3": "Primary Care Provider",
             "P4": "Prior Insurance Carrier",


### PR DESCRIPTION
This PR adds several additional entity identifier codes, used in Subscriber/Dependent Benefit Related Entity Name in the 27x spec.  Also sets the entity identifier enum to allow raw_unknowns, so that unknown entity identifiers can still be be processed in the future.
